### PR TITLE
Use Python 3

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,9 +6,7 @@ services:
     build: ./test
     command:
       - -c
-      - pytest -p no:cacheprovider /test/tests.py
-    environment:
-      PYTHONPATH: /opt/omero/server/OMERO.server/lib/python/
+      - /opt/omero/server/venv3/bin/pytest -p no:cacheprovider /test/tests.py
     networks:
       - omero
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   database:
-    image: "postgres:10"
+    image: "postgres:11"
     environment:
       POSTGRES_USER: omero
       POSTGRES_DB: omero

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - "./certs:/etc/ssl/selfsigned:ro${VOLOPTS-}"
 
   omeroweb:
-    image: "openmicroscopy/omero-web-standalone:latest"
+    image: "openmicroscopy/omero-web-standalone:5.6"
     environment:
       OMEROHOST: omeroserver
       CONFIG_omero_web__check_version: "false"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/omero-server:latest
+FROM openmicroscopy/omero-server:5.6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN cd /opt/omero/server/ && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/omero-server:5.6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN cd /opt/omero/server/ && \
-    /opt/omero/server/venv3/bin/omego download -q --release 5.5 server --sym auto
+    /opt/omero/server/venv3/bin/omego download -q --release 5.6 server --sym auto
 
 USER root
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,7 +7,7 @@ RUN cd /opt/omero/server/ && \
 USER root
 
 # OMERO.py plugins
-RUN pip install \
+RUN /opt/omero/server/venv3/bin/python -m pip install \
     omero-cli-render \
     omero-metadata
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/omero-server:5.6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN cd /opt/omero/server/ && \
-    /opt/omero/omego/bin/omego download -q --release 5.5 server --sym auto
+    /opt/omero/server/venv3/bin/omego download -q --release 5.5 server --sym auto
 
 USER root
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/omero-server:latest
+FROM openmicroscopy/omero-server:5.6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN cd /opt/omero/server/ && \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/omero-server:5.6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN cd /opt/omero/server/ && \
-    /opt/omero/server/venv3/bin/omego download -q --release 5.5 server --sym auto
+    /opt/omero/server/venv3/bin/omego download -q --release 5.6 server --sym auto
 
 USER root
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -6,7 +6,7 @@ RUN cd /opt/omero/server/ && \
 
 USER root
 
-RUN pip install pytest
+RUN /opt/omero/server/venv3/bin/python -m pip install pytest
 
 USER omero-server
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/omero-server:5.6
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 RUN cd /opt/omero/server/ && \
-    /opt/omero/omego/bin/omego download -q --release 5.5 server --sym auto
+    /opt/omero/server/venv3/bin/omego download -q --release 5.5 server --sym auto
 
 USER root
 

--- a/wait_for_login.sh
+++ b/wait_for_login.sh
@@ -4,7 +4,7 @@ set -eu
 
 OMERO_USER=root
 OMERO_PASS=omero
-OMERO=/opt/omero/server/OMERO.server/bin/omero
+OMERO=/opt/omero/server/venv3/bin/omero
 
 # Wait up to 2 mins
 i=0


### PR DESCRIPTION
Recent cron build started failing due on `pip install pytest`.
Rather than start pinning versions, this change starts consuming
the milestone releases of OMERO 5.6.

see: https://travis-ci.org/ome/docker-example-omero-websockets/builds/631825422